### PR TITLE
Remove whitespace at the end of callback URL

### DIFF
--- a/Twitter/templates/default/admin/twitter.tpl.php
+++ b/Twitter/templates/default/admin/twitter.tpl.php
@@ -18,7 +18,7 @@
                         The callback URL should be set to:
                     </p>
                     <p>
-                        <input type="text" name="ignore" class="span4" value="<?=\Idno\Core\site()->config()->url . 'twitter/callback'?> " />
+                        <input type="text" name="ignore" class="span4" value="<?=\Idno\Core\site()->config()->url . 'twitter/callback'?>" />
                     </p>
                     <p>
                         Once you've finished, fill in the details below:


### PR DESCRIPTION
Seems like a stupid change were it not for the fact that Twitter's App submission form doesn't strip the whitespace and for the life of me I couldn't figure out what part of the URL they had an issue with.
