### PR TITLE
Update installation docs for current Known UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-Twitter for idno
-================
+Twitter for Known
+=================
 
-This plugin provides POSSE support for idno.
+This plugin provides POSSE support for Known.
 
 Installation
 ------------
 
-* Drop the Twitter folder into the IdnoPlugins folder of your idno installation.
-* Log into idno and click on Administration.
-* Click "install" next to Twitter.
+* Drop the Twitter folder into the IdnoPlugins folder of your Known installation.
+* Log into Known and click **Site Configuration**.
+* On the **Site Features** tab, click **Enable** next to Twitter. A **Twitter**
+  entry is added to the site configuration menu.
+* Click **Twitter** in the site configuration menu. Set up your custom Twitter
+  application, which will post tweets for your Known instance, and save the API
+  key and API secret.
+
+Once you have installed and configured the Twitter plugin, each user of your
+Known instance will be able to set up Twitter syndication support using the
+**Twitter** entry in the user settings menu.
 
 License
 -------


### PR DESCRIPTION
Add more explicit instructions for setting up the instance-level
Twitter support through the "Site configuration" menu before
users will be able to connect to Twitter. This will help avoid
the currently raw error that gets thrown when the Twitter API
keys have not yet been configured.

Use "Known" to refer to the software instead of "idno".

Signed-off-by: Dan Scott dan@coffeecode.net
