### PR TITLE
use config()->getDisplayURL() instead of config()->getURL()

### DIFF
--- a/Pages/Account.php
+++ b/Pages/Account.php
@@ -18,7 +18,7 @@
                 /*if ($twitter = \Idno\Core\site()->plugins()->get('Twitter')) {
                     $oauth_url = $twitter->getAuthURL();
                 }*/
-                $oauth_url = \Idno\Core\site()->config()->getURL() . 'twitter/auth';
+                $oauth_url = \Idno\Core\site()->config()->getDisplayURL() . 'twitter/auth';
                 $t = \Idno\Core\site()->template();
                 $body = $t->__(array('oauth_url' => $oauth_url))->draw('account/twitter');
                 $t->__(array('title' => 'Twitter', 'body' => $body))->drawPage();

--- a/Pages/Callback.php
+++ b/Pages/Callback.php
@@ -46,7 +46,7 @@
 
                         if (!empty($_SESSION['onboarding_passthrough'])) {
                             unset($_SESSION['onboarding_passthrough']);
-                            $this->forward(\Idno\Core\site()->config()->getURL() . 'begin/connect-forwarder');
+                            $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'begin/connect-forwarder');
                         }
                         $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'account/twitter');
                     }

--- a/templates/default/admin/twitter.tpl.php
+++ b/templates/default/admin/twitter.tpl.php
@@ -9,7 +9,7 @@
 </div>
 <div class="row">
     <div class="span10 offset1">
-        <form action="<?=\Idno\Core\site()->config()->getURL()?>admin/twitter/" class="form-horizontal" method="post">
+        <form action="<?=\Idno\Core\site()->config()->getDisplayURL()?>admin/twitter/" class="form-horizontal" method="post">
             <div class="control-group">
                 <div class="controls-config">
                     <p>

--- a/templates/default/admin/twitter/menu.tpl.php
+++ b/templates/default/admin/twitter/menu.tpl.php
@@ -1,1 +1,1 @@
-<li <?php if ($_SERVER['REQUEST_URI'] == '/admin/twitter/') echo 'class="active"'; ?>><a href="<?=\Idno\Core\site()->config()->getURL()?>admin/twitter/">Twitter</a></li>
+<li <?php if ($_SERVER['REQUEST_URI'] == '/admin/twitter/') echo 'class="active"'; ?>><a href="<?=\Idno\Core\site()->config()->getDisplayURL()?>admin/twitter/">Twitter</a></li>

--- a/templates/default/onboarding/connect/twitter.tpl.php
+++ b/templates/default/onboarding/connect/twitter.tpl.php
@@ -1,9 +1,9 @@
 <?php
 
     if (empty(\Idno\Core\site()->session()->currentUser()->twitter)) {
-        $login_url = \Idno\Core\site()->config()->getURL() . 'twitter/auth';
+        $login_url = \Idno\Core\site()->config()->getDisplayURL() . 'twitter/auth';
     } else {
-        $login_url = \Idno\Core\site()->config()->getURL() . 'twitter/deauth';
+        $login_url = \Idno\Core\site()->config()->getDisplayURL() . 'twitter/deauth';
     }
 
 ?>


### PR DESCRIPTION
This is in reaction to https://github.com/idno/idno/commit/6c916a0234723ca805935b50e5d3e883faa564fe

I did not change the occurences of `$event->data()['object']->getURL()` and `$event->data()['object']->getShortURL` in Main.php, because I reckoned the event should probably already carry the correct URL when it reaches the the Twitter plugin.