### PR TITLE
correcting index name for mime types of attachments

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -243,7 +243,7 @@
                                     $media    = '';
                                     $filename = tempnam(sys_get_temp_dir(), 'idnotwitter');
                                     file_put_contents($filename, $bytes);
-                                    $media .= "@{$filename};type=" . $attachment['mime_type'] . ';filename=' . $attachment['filename'];
+                                    $media .= "@{$filename};type=" . $attachment['mime-type'] . ';filename=' . $attachment['filename'];
                                 }
                             }
                         }


### PR DESCRIPTION
$attachments = $object->getAttachments() returns an indix mime-type (and not mime_type).
This prevents the photo to post to Twitter.