### PR TITLE
Support Twitter's new 280 char default length

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -14,6 +14,7 @@
                 parent::init();
                 require_once __DIR__ . '/autoloader.php';
                 $this->brevity = new Brevity();
+		$this->brevity->setTargetLength(280);
             }
 
             function registerPages()


### PR DESCRIPTION
Twitter has changed the default length of tweets. Support this.

Closes #52